### PR TITLE
fix(engines): remove unnecessary array for `search` method

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -139,12 +139,12 @@ Immediate plays the first of the given tracks, skips current track if playing. T
   // get your voice channel here, e.g. from a slash command
   const voiceChannel;
 
-  const searchResults = await player.search("Luis Fonsi - Despacito");
-  if (searchResults.length && searchResults[0].tracks.length) {
+  const searchResult = await player.search("Luis Fonsi - Despacito");
+  if (searchResult?.tracks.length) {
     await player.play({
       channel: voiceChannel,
       // play first matched song for Despacito
-      tracks: searchResults[0].tracks.slice(1),
+      tracks: searchResult.tracks[0],
     });
   }
   ```
@@ -167,11 +167,11 @@ Adds the given tracks to the end of the queue. Immediately plays first track in 
   // get your voice channel here, e.g. from a slash command
   const voiceChannel;
 
-  const searchResults = await player.search("Some YouTube Playlist");
-  if (searchResults.length && searchResults[0].tracks.length) {
+  const searchResult = await player.search("Some YouTube Playlist");
+  if (searchResult?.tracks.length) {
     await player.add({
       channel: voiceChannel,
-      tracks: searchResults[0].tracks,
+      tracks: searchResult.tracks,
     });
   }
   ```
@@ -411,12 +411,12 @@ Searches tracks for the given query.
 - **Example**
 
   ```ts
-  const searchResults = await player.search("Luis Fonsi - Despacito");
-  if (searchResults.length) {
+  const searchResult = await player.search("Luis Fonsi - Despacito");
+  if (!searchResult?.tracks.length) {
     console.log("No search results found for Despacito");
   } else {
     console.log(
-      `Found ${searchResults[0].tracks.length} matching tracks for Despacito`
+      `Found ${searchResult.tracks.length} matching tracks for Despacito`
     );
   }
   ```

--- a/docs/guide/engines.md
+++ b/docs/guide/engines.md
@@ -9,7 +9,7 @@ Player engines are the heart of `discord-player-plus`. They are responsible for 
 When you use `player.search()` the engine will be detected automatically but you can also specify which engine you want to use with:
 
 ```ts
-const searchResults = await player.search("my song to search", {
+const searchResult = await player.search("my song to search", {
   source: "spotify",
 });
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -127,12 +127,12 @@ const player = playerManager.get("my-guild-id");
 // get your voice channel here, e.g. from a slash command
 const voiceChannel;
 
-const searchResults = await player.search("Luis Fonsi - Despacito");
-if (searchResults.length && searchResults[0].tracks.length) {
+const searchResult = await player.search("Luis Fonsi - Despacito");
+if (searchResult?.tracks.length) {
   await player.play({
     channel: voiceChannel,
     // play first matched song for Despacito
-    tracks: searchResults[0].tracks.slice(1),
+    tracks: searchResult.tracks[0],
   });
 }
 ```

--- a/src/__tests__/engines/file.spec.ts
+++ b/src/__tests__/engines/file.spec.ts
@@ -1,6 +1,6 @@
 import { IAudioMetadata, parseFile } from "music-metadata";
 import path from "path";
-import { afterEach, describe, expect, it, Mock, test, vi } from "vitest";
+import { Mock, afterEach, describe, expect, it, test, vi } from "vitest";
 import { fileEngine } from "../../engines/file";
 import { Track } from "../../types/engines";
 
@@ -79,20 +79,15 @@ describe("file engine", () => {
 
   it("searches track with metadata", async () => {
     // should return no result when fileRoot is not set
-    let searchResults = await fileEngine.search(expectedTrack.url, {});
-    expect(searchResults.length).toBe(0);
+    let searchResult = await fileEngine.search(expectedTrack.url, {});
+    expect(searchResult).toBe(null);
 
     // should return result when fileRoot is set
-    searchResults = await fileEngine.search(expectedTrack.url, { fileRoot });
-    const result = searchResults[0];
-    expect(result).toBeDefined();
-    expect(result.playlist).toBeUndefined();
-    expect(result.source).toBe("file");
-    expect(result.tracks.length).toBe(1);
-
-    const track = result.tracks[0];
-    expect(track).toBeDefined();
-    expect(track).toEqual(expectedTrack);
+    searchResult = await fileEngine.search(expectedTrack.url, { fileRoot });
+    expect(searchResult).toStrictEqual({
+      source: "file",
+      tracks: [expectedTrack],
+    });
   });
 
   it("searches track without metadata", async () => {
@@ -106,25 +101,20 @@ describe("file engine", () => {
       source: "file",
     };
 
-    let searchResults = await fileEngine.search(expectedTrack.url, {
+    let searchResult = await fileEngine.search(expectedTrack.url, {
       fileRoot,
     });
-    const result = searchResults[0];
-    expect(result).toBeDefined();
-    expect(result.playlist).toBeUndefined();
-    expect(result.source).toBe("file");
-    expect(result.tracks.length).toBe(1);
-
-    const track = result.tracks[0];
-    expect(track).toBeDefined();
-    expect(track).toEqual(expectedTrack);
+    expect(searchResult).toEqual({
+      source: "file",
+      tracks: [expectedTrack],
+    });
 
     // handles metadata error
     (parseFile as Mock).mockImplementation(() => {
       throw Error("This should be handled");
     });
-    searchResults = await fileEngine.search(expectedTrack.url, { fileRoot });
-    expect(searchResults.length).toBe(0);
+    searchResult = await fileEngine.search(expectedTrack.url, { fileRoot });
+    expect(searchResult).toBe(null);
   });
 
   it("gets stream", async () => {

--- a/src/__tests__/engines/youtube.spec.ts
+++ b/src/__tests__/engines/youtube.spec.ts
@@ -47,8 +47,8 @@ describe.concurrent("youtube engine", () => {
   });
 
   test("should not return search results for empty query", async () => {
-    const results = await youtubeEngine.search("   ", {}, {});
-    expect(results).toStrictEqual([]);
+    const result = await youtubeEngine.search("   ", {}, {});
+    expect(result).toBeNull();
   });
 
   test("should return search results for video query", async () => {
@@ -56,17 +56,15 @@ describe.concurrent("youtube engine", () => {
 
     const query = "https://www.youtube.com/watch?v=testVideoId";
 
-    const results = await youtubeEngine.search(query, {}, {});
+    const result = await youtubeEngine.search(query, {}, {});
 
     expect(searchSpy).toHaveBeenCalledWith(query, {
       source: { youtube: "video" },
     });
-    expect(results).toStrictEqual([
-      {
-        source: "youtube",
-        tracks: [expectedTrack],
-      },
-    ]);
+    expect(result).toStrictEqual({
+      source: "youtube",
+      tracks: [expectedTrack],
+    });
   });
 
   test("should return search results for playlist query", async () => {
@@ -85,7 +83,7 @@ describe.concurrent("youtube engine", () => {
 
     const query = "https://www.youtube.com/playlist?list=testPlaylistId";
 
-    const results = await youtubeEngine.search(query, {}, {});
+    const result = await youtubeEngine.search(query, {}, {});
 
     const expectedPlaylist: Playlist = {
       title: "testPlaylistTitle",
@@ -96,13 +94,11 @@ describe.concurrent("youtube engine", () => {
     expect(validateSpy).toHaveBeenCalledWith(query);
     expect(playlistInfoSpy).toHaveBeenCalledWith(query, { incomplete: true });
 
-    expect(results).toStrictEqual([
-      {
-        source: "youtube",
-        playlist: expectedPlaylist,
-        tracks: [{ ...expectedTrack, playlist: expectedPlaylist }],
-      },
-    ]);
+    expect(result).toStrictEqual({
+      source: "youtube",
+      playlist: expectedPlaylist,
+      tracks: [{ ...expectedTrack, playlist: expectedPlaylist }],
+    });
   });
 
   test("searches tracks with limit", async () => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -105,9 +105,8 @@ export async function playTracks(
 
   // search tracks
   const searchResult = await player.search(query);
-  const firstResult = searchResult[0];
 
-  if (!firstResult || !firstResult.tracks.length) {
+  if (!searchResult?.tracks.length) {
     await interaction.followUp({
       content: playerManager.translations.play.noTracksFound.replace(
         "{query}",
@@ -119,14 +118,14 @@ export async function playTracks(
 
   // play track(s)
   const playOptions: PlayOptions = {
-    tracks: firstResult.playlist
-      ? firstResult.tracks
-      : firstResult.tracks.slice(0, 1),
+    tracks: searchResult.playlist
+      ? searchResult.tracks
+      : searchResult.tracks.slice(0, 1),
     channel: interaction.member.voice.channel,
   };
 
   if (immediate) await player.play(playOptions);
   else await player.add(playOptions);
 
-  return firstResult;
+  return searchResult;
 }

--- a/src/commands/insert.ts
+++ b/src/commands/insert.ts
@@ -47,9 +47,8 @@ export const createInsertCommand: CreateCommandFunc = (
 
       // search tracks
       const searchResult = await player.search(query);
-      const firstResult = searchResult[0];
 
-      if (!firstResult || !firstResult.tracks.length) {
+      if (!searchResult?.tracks.length) {
         await interaction.followUp({
           content: playerManager.translations.play.noTracksFound.replace(
             "{query}",
@@ -61,7 +60,7 @@ export const createInsertCommand: CreateCommandFunc = (
 
       const queue = player.getQueue();
 
-      const track = firstResult.tracks[0];
+      const track = searchResult.tracks[0];
       player.insert(track, trackIndex);
 
       // human friendly track position

--- a/src/engines/file.ts
+++ b/src/engines/file.ts
@@ -2,7 +2,7 @@ import { StreamType } from "@discordjs/voice";
 import { stat } from "fs/promises";
 import { IAudioMetadata, parseFile } from "music-metadata";
 import path from "path";
-import { PlayerEngine, SearchResult, Track } from "../types/engines";
+import { PlayerEngine, Track } from "../types/engines";
 import { isSubPath } from "../utils/fs";
 
 async function isFile(path: string): Promise<boolean> {
@@ -24,15 +24,15 @@ export const fileEngine = {
   },
   async search(query, playerOptions) {
     // refuse to search files outside of fileRoot
-    if (!this.isResponsible(query, playerOptions)) return [];
-    if (!(await isFile(query))) return [];
+    if (!this.isResponsible(query, playerOptions)) return null;
+    if (!(await isFile(query))) return null;
 
     // get file metadata
     let metadata: IAudioMetadata;
     try {
       metadata = await parseFile(query, { skipCovers: true });
     } catch (e) {
-      return [];
+      return null;
     }
 
     const track: Track = {
@@ -43,8 +43,7 @@ export const fileEngine = {
       source: this.source,
     };
 
-    const searchResult: SearchResult = { tracks: [track], source: this.source };
-    return [searchResult];
+    return { tracks: [track], source: this.source };
   },
   async getStream(track, playerOptions) {
     // refuse to stream files outside of fileRoot

--- a/src/engines/youtube.ts
+++ b/src/engines/youtube.ts
@@ -14,7 +14,7 @@ export const youtubeEngine = {
   },
   async search(query, _, searchOptions) {
     query = query.trim();
-    if (!query) return [];
+    if (!query) return null;
 
     if (playDl.yt_validate(query) === "playlist") {
       return await searchPlaylist(query, searchOptions?.limit);
@@ -25,11 +25,10 @@ export const youtubeEngine = {
       limit: searchOptions?.limit,
     });
 
-    const searchResult: SearchResult = {
+    return {
       tracks: videos.map((video) => mapVideoToTrack(video)),
       source: this.source,
     };
-    return [searchResult];
   },
   async getStream(track, playerOptions) {
     return await playDl.stream(track.url, {
@@ -47,7 +46,7 @@ export const youtubeEngine = {
 const searchPlaylist = async (
   query: string,
   limit?: number
-): Promise<SearchResult[]> => {
+): Promise<SearchResult> => {
   const playlistInfo = await playDl.playlist_info(query, { incomplete: true });
   let playlistVideos: YouTubeVideo[] = playlistInfo.page(1);
 
@@ -69,16 +68,14 @@ const searchPlaylist = async (
       }
     : undefined;
 
-  return [
-    {
-      tracks: playlistVideos.map<Track>((video) => ({
-        ...mapVideoToTrack(video),
-        playlist,
-      })),
+  return {
+    tracks: playlistVideos.map<Track>((video) => ({
+      ...mapVideoToTrack(video),
       playlist,
-      source: youtubeEngine.source,
-    },
-  ];
+    })),
+    playlist,
+    source: youtubeEngine.source,
+  };
 };
 
 const mapVideoToTrack = (video: YouTubeVideo): Track => {

--- a/src/player.ts
+++ b/src/player.ts
@@ -12,12 +12,7 @@ import {
 import { VoiceBasedChannel } from "discord.js";
 import { TypedEmitter } from "tiny-typed-emitter";
 import { playerEngines } from "./engines";
-import {
-  PlayerEngine,
-  SearchOptions,
-  SearchResult,
-  Track,
-} from "./types/engines";
+import { PlayerEngine, SearchOptions, Track } from "./types/engines";
 import {
   PlayerError,
   PlayerErrorCode,
@@ -447,11 +442,11 @@ export class Player extends TypedEmitter<PlayerEvents> {
   async search(
     query: string,
     options?: SearchOptions
-  ): Promise<SearchResult[]> {
+  ): ReturnType<PlayerEngine["search"]> {
     const trackSource =
       options?.source || (await this.detectTrackSource(query));
     const playerEngine = this.getEngine(trackSource);
-    if (!playerEngine) return [];
+    if (!playerEngine) return null;
     return await playerEngine.search(query, this.options, options);
   }
 

--- a/src/types/engines.ts
+++ b/src/types/engines.ts
@@ -19,7 +19,7 @@ export interface PlayerEngine {
     query: string,
     playerOptions: PlayerOptions,
     options?: SearchOptions
-  ): Promise<SearchResult[]>;
+  ): Promise<SearchResult | null>;
   /** Gets the playable stream for the given track. */
   getStream(
     track: Track,


### PR DESCRIPTION
BREAKING CHANGE: Changed type `PlayerEngine` and all pre-built engines (youtube, spotify and file) to return `SearchResult|null` instead of `SearchResult[]`. The previous return value just wrapped the search result into an array so its length was always 1. Thats why it has been changed.
BREAKING CHANGE: `player.search()` now returns `SearchResult|null` instead of `SearchResult[]`